### PR TITLE
Add options to add apt key from upstream keyfile

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,5 @@ nginx_search_config_paths: []
 nginx_host_config_file_path: "{{ nginx_host_config_path | default(inventory_hostname) }}/nginx.conf"
 nginx_host_config_ssl_path: "{{ nginx_host_config_path | default(inventory_hostname) }}/ssl"
 nginx_config_path: /etc/nginx
+
+nginx_use_upstream_apt_key: false

--- a/tasks/nginx_pre.yml
+++ b/tasks/nginx_pre.yml
@@ -5,9 +5,18 @@
   tags:
     - nginx-install
 
+- name: Add Nginx reporitory key from keyfile
+  apt_key:
+    url: "{{ nginx_apt_key_url }}"
+    state: present
+  when: nginx_use_upstream_apt_key
+  tags:
+    - nginx-install
+
 - name: Add Nginx repository key
   apt_key:
     keyserver: "{{ nginx_apt_key_server }}"
     id: "{{ nginx_apt_key_id }}"
+  when: not nginx_use_upstream_apt_key
   tags:
     - nginx-install

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,3 +3,4 @@ nginx_deb_repository: "deb http://nginx.org/packages/ubuntu/ {{ ansible_distribu
 nginx_apt_key_id: ABF5BD827BD9BF62
 nginx_apt_key_server: keyserver.ubuntu.com
 nginx_apt_package: nginx
+nginx_apt_key_url: "https://nginx.org/keys/nginx_signing.key"


### PR DESCRIPTION
Add options to add apt key from upstream keyfile since some server cannot finish add apt key from keyserver.ubuntu.com (wait long time and nothing happens) 
by ulTimate
