### PR TITLE
RedHat 7 fix

### DIFF
--- a/tasks/nginx_post.yml
+++ b/tasks/nginx_post.yml
@@ -1,4 +1,13 @@
 ---
+- name: Ensure rsync and libsemanage-python is installed (RedHat)
+  when: ansible_os_family == "RedHat"
+  yum: 
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - rsync
+    - libsemanage-python
+
 # synchronize module does not work well with sudo with password
 # https://github.com/ansible/ansible/issues/20769#issuecomment-321341370
 - name: Allow rsync without SUDO password

--- a/tasks/nginx_pre.yml
+++ b/tasks/nginx_pre.yml
@@ -35,6 +35,7 @@
   command: "apt-key adv --keyserver-options http-proxy={{ proxy_env.http_proxy }} --fetch-keys 'http://{{ nginx_apt_key_server }}/pks/lookup?op=get&search=0x{{ nginx_apt_key_id }}'"
   when:
     - ansible_os_family == "Debian"
+    - nginx_use_upstream_apt_key is defined
     - not nginx_use_upstream_apt_key
     - proxy_env is defined
   tags:

--- a/tasks/nginx_pre.yml
+++ b/tasks/nginx_pre.yml
@@ -11,8 +11,9 @@
     url: "{{ nginx_apt_key_url }}"
     state: present
   when:
-    - nginx_use_upstream_apt_key
     - ansible_os_family == "Debian"
+    - nginx_use_upstream_apt_key is defined
+    - nginx_use_upstream_apt_key
   tags:
     - nginx-install
 
@@ -21,9 +22,10 @@
     keyserver: "{{ nginx_apt_key_server }}"
     id: "{{ nginx_apt_key_id }}"
   when:
+    - ansible_os_family == "Debian"
+    - nginx_use_upstream_apt_key is defined
     - not nginx_use_upstream_apt_key
     - proxy_env is not defined
-    - ansible_os_family == "Debian"
   tags:
     - nginx-install
 
@@ -32,9 +34,9 @@
 - name: Add Nginx repository key (proxy environment) (Debian/Ubuntu)
   command: "apt-key adv --keyserver-options http-proxy={{ proxy_env.http_proxy }} --fetch-keys 'http://{{ nginx_apt_key_server }}/pks/lookup?op=get&search=0x{{ nginx_apt_key_id }}'"
   when:
+    - ansible_os_family == "Debian"
     - not nginx_use_upstream_apt_key
     - proxy_env is defined
-    - ansible_os_family == "Debian"
   tags:
     - nginx-install
 


### PR DESCRIPTION
- Fix nginx_use_upstream_apt_key with RedHat
- Add rsync and libsemanage-python checks before post install start